### PR TITLE
Data version switching in jobs

### DIFF
--- a/datasm/util.py
+++ b/datasm/util.py
@@ -256,6 +256,7 @@ def latest_dspath_version(dspath):
 
 def set_version_in_user_metadata(metadata_path, dsversion):     # set version "vYYYYMMDD" in user metadata
 
+    log_message("info", f"set_version_in_user_metadata: path={metadata_path}")
     in_data = json_readfile(metadata_path)
     in_data["version"] = dsversion
     json_writefile(in_data,metadata_path)

--- a/datasm/workflows/jobs/GenerateAtmMonCMIP.py
+++ b/datasm/workflows/jobs/GenerateAtmMonCMIP.py
@@ -1,11 +1,10 @@
-import os
-from pathlib import Path
-from subprocess import PIPE, Popen
-from tempfile import NamedTemporaryFile
-
 import yaml
-from datasm.util import log_message, get_UTC_YMD, get_first_nc_file, set_version_in_user_metadata
+import os
+
+from subprocess import Popen, PIPE
+from tempfile import NamedTemporaryFile
 from datasm.workflows.jobs import WorkflowJob
+from datasm.util import log_message, get_UTC_YMD, set_version_in_user_metadata
 
 NAME = 'GenerateAtmMonCMIP'
 
@@ -22,42 +21,41 @@ class GenerateAtmMonCMIP(WorkflowJob):
     def resolve_cmd(self):
 
         raw_dataset = self.requires['atmos-native-mon']
+        cwl_config = self.config['cmip_atm_mon']
 
         parameters = {'data_path': raw_dataset.latest_warehouse_dir}
-        cwl_config = self.config['cmip_atm_mon']
-        parameters.update(cwl_config)   # picks up frequency, num_workers, account, partition, and timeout.
+        parameters.update(cwl_config)
 
         _, _, _, model_version, experiment, variant, table, cmip_var, _ = self.dataset.dataset_id.split('.')
+
+        # seek "model_version" for v2 accommodations
 
         # if we want to run all the variables
         # we can pull them from the dataset spec
         if cmip_var == 'all':
             is_all = True
-            in_cmip_vars = [x for x in self._spec['tables'][table] if x != 'all']
+            cmip_var = [x for x in self._spec['tables'][table] if x != 'all']
         else:
             is_all = False
-            in_cmip_vars = [cmip_var]
-
-        info_file = NamedTemporaryFile(delete=False)
-        cmd = f"e3sm_to_cmip --info -i {parameters['data_path']} --freq mon -v {', '.join(in_cmip_vars)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
-
-        proc = Popen(cmd.split(), stdout=PIPE, stderr=PIPE)
-        _, err = proc.communicate()
-        if err:
-            log_message("info", f"(stderr) checking variables: {err}")
-            # return None # apparently not a serious error, merely data written to stderr.
-
-        with open(info_file.name, 'r') as instream:
-            variable_info = yaml.load(instream, Loader=yaml.SafeLoader)
+            cmip_var = [cmip_var]
 
         std_var_list = []
         std_cmor_list = []
         plev_var_list = []
         plev_cmor_list = []
 
+        info_file = NamedTemporaryFile(delete=False)
+        cmd = f"e3sm_to_cmip --info -i {parameters['data_path']} --freq mon -v {', '.join(cmip_var)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
+        proc = Popen(cmd.split(), stdout=PIPE, stderr=PIPE)
+        _, err = proc.communicate()
+        if err:
+            log_message("info", f"(stderr) checking variables: {err}")
+            # return None # apparently not a serious error, merely data written to stderr.
+
         plev = False
         mlev = False
-
+        with open(info_file.name, 'r') as instream:
+            variable_info = yaml.load(instream, Loader=yaml.SafeLoader)
         for item in variable_info:
             if ',' in item['E3SM Variables']:
                 e3sm_var = [v.strip() for v in item['E3SM Variables'].split(',')]
@@ -80,6 +78,7 @@ class GenerateAtmMonCMIP(WorkflowJob):
         parameters['plev_cmor_list'] = plev_cmor_list                   # for plev, else no harm if empty
 
         if model_version == "E3SM-2-0":
+            parameters['find_pattern'] = ".eam.h0"
             parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
             if plev and not mlev:
                 cwl_workflow = "atm-mon-plev-eam/atm-plev.cwl"
@@ -88,6 +87,7 @@ class GenerateAtmMonCMIP(WorkflowJob):
             elif plev and mlev:
                 cwl_workflow = "atm-unified-eam/atm-unified.cwl"
         else:
+            parameters['find_pattern'] = ".cam.h0"
             parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
             if plev and not mlev:
                 cwl_workflow = "atm-mon-plev/atm-plev.cwl"
@@ -96,10 +96,12 @@ class GenerateAtmMonCMIP(WorkflowJob):
             elif plev and mlev:
                 cwl_workflow = "atm-unified/atm-unified.cwl"
 
+        workflow_path = os.path.join(self.config['cwl_workflows_path'], cwl_workflow)
         log_message("info", f"resolve_cmd: Employing cwl_workflow {cwl_workflow}")
 
         parameters['tables_path'] = self.config['cmip_tables_path']
-        parameters['metadata_path'] = os.path.join(self.config['cmip_metadata_path'], model_version, f"{experiment}_{variant}.json")  # model_version = CMIP6 "Source"
+        parameters['metadata_path'] = os.path.join(
+            self.config['cmip_metadata_path'], model_version, f"{experiment}_{variant}.json")   # model_version = CMIP6 "Source"
 
         # force dataset output version here
         ds_version = "v" + get_UTC_YMD()
@@ -107,19 +109,18 @@ class GenerateAtmMonCMIP(WorkflowJob):
         log_message("info", f"Set dataset version in {parameters['metadata_path']} to {ds_version}")
 
         # step two, write out the parameter file and setup the temp directory
-        var_id = 'all' if is_all else in_cmip_vars[0]
+        self._cmip_var = 'all' if is_all else cmip_var[0]
         parameter_path = os.path.join(
-            self._slurm_out, f"{self.dataset.experiment}-{self.dataset.model_version}-{self.dataset.ensemble}-atm-cmip-mon-{var_id}.yaml")
+            self._slurm_out, f"{self.dataset.experiment}-{self.dataset.model_version}-{self.dataset.ensemble}-atm-cmip-mon-{self._cmip_var}.yaml")
         with open(parameter_path, 'w') as outstream:
             yaml.dump(parameters, outstream)
 
         # step three, render out the CWL run command
         # OVERRIDE : needed to be "pub_dir" to find the data, but back to "warehouse" to write results to the warehouse
-        outpath = '/p/user_pub/e3sm/warehouse'  # was "self.dataset.warehouse_base", but -w <pub_root> for input selection interferes.
-        cwl_workflow_path = os.path.join(self.config['cwl_workflows_path'], cwl_workflow)
+        self.dataset.warehouse_base = '/p/user_pub/e3sm/warehouse'      # testing testing testing ...
 
         if not self.serial:
             parallel = "--parallel"
         else:
             parallel = ''
-        self._cmd = f"cwltool --outdir {outpath} --tmpdir-prefix={self.tmpdir} {parallel} --preserve-environment UDUNITS2_XML_PATH {cwl_workflow_path} {parameter_path}"
+        self._cmd = f"cwltool --outdir {self.dataset.warehouse_base}  --tmpdir-prefix={self.tmpdir} {parallel} --preserve-environment UDUNITS2_XML_PATH {workflow_path} {parameter_path}"

--- a/datasm/workflows/jobs/GenerateAtmMonClimo.py
+++ b/datasm/workflows/jobs/GenerateAtmMonClimo.py
@@ -27,20 +27,23 @@ class GenerateAtmMonClimo(WorkflowJob):
         dsid = f"{self.dataset.dataset_id}"
         model = dsid.split(".")[1][0]
         native_resolution = dsid.split(".")[3]
-        # NOTE: available grids are defined in resources/datasm_config.yaml
-        mapkey = "ne30_to_180x360"
-        if native_resolution == "0_25deg_atm_18-6km_ocean":
-            mapkey = "ne120np4_to_cmip6_720x1440"
-            # or else maybe "ne120np4_to_cmip6_180x360"
-
-        map_path = self.config['grids'][mapkey]
 
         filename = Path(inpath).glob('*.nc').__next__()
         if model == "1":
             idx = re.search('\.cam\.h\d\.', filename.name)
-        else:
+            if native_resolution == "1deg_atm_60-30km_ocean":
+                mapkey = "v1_ne30_to_180x360"
+            else: # assume
+                mapkey = "v1_ne120np4_to_cmip6_720x1440"
+        else: # assume v2
             idx = re.search('\.eam\.h\d\.', filename.name)
+            if native_resolution in [ "1deg_atm_60-30km_ocean", "LR" ]:
+                mapkey = "v2_ne30_to_180x360"
+            else: # assume
+                mapkey = "v2_ne120pg2_to_cmip6_720x1440"
         casename = filename.name[:idx.start()]
+        # NOTE: available grids are defined in resources/datasm_config.yaml
+        map_path = self.config['grids'][mapkey]
 
         native_out = f"{os.environ.get('TMPDIR', '/tmp')}{os.sep}{self.dataset.dataset_id}/climo/"
         self._cmd = f"""

--- a/datasm/workflows/jobs/GenerateAtmMonTimeseries.py
+++ b/datasm/workflows/jobs/GenerateAtmMonTimeseries.py
@@ -28,7 +28,7 @@ class GenerateAtmMonTimeseries(WorkflowJob):
         # NOTE: available grids are defined in resources/datasm_config.yaml
         mapkey = "ne30_to_180x360"
         if native_resolution == "0_25deg_atm_18-6km_ocean":
-            mapkey = "ne120np4_to_cmip6_720x1440"
+            mapkey = "ne120pg2_to_cmip6_720x1440"
             # or else maybe "ne120np4_to_cmip6_180x360"
 
         map_path = self.config['grids'][mapkey]

--- a/datasm/workflows/jobs/GenerateLndMonCMIP.py
+++ b/datasm/workflows/jobs/GenerateLndMonCMIP.py
@@ -95,9 +95,11 @@ class GenerateLndMonCMIP(WorkflowJob):
         parameters['metadata_path'] = os.path.join( self.config['cmip_metadata_path'], model_version, f"{experiment}_{variant}.json")
         if model_version == "E3SM-2-0":
             parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
+            parameters['find_pattern'] = ".elm.h0"
             cwl_workflow = "lnd-elm/lnd.cwl"
         else:
             parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
+            parameters['find_pattern'] = ".clm2.h0"
             cwl_workflow = "lnd-n2n/lnd.cwl"
 
         cwl_workflow_path = os.path.join(self.config['cwl_workflows_path'], cwl_workflow)

--- a/datasm/workflows/jobs/GenerateLndMonCMIP.py
+++ b/datasm/workflows/jobs/GenerateLndMonCMIP.py
@@ -90,15 +90,17 @@ class GenerateLndMonCMIP(WorkflowJob):
         parameters['one_land_file'] = os.path.join(
             parameters['lnd_data_path'],
             os.listdir(parameters['lnd_data_path']).pop())
-        cwl_workflow = "lnd-n2n/lnd.cwl"
 
         parameters['tables_path'] = self.config['cmip_tables_path']
         parameters['metadata_path'] = os.path.join( self.config['cmip_metadata_path'], model_version, f"{experiment}_{variant}.json")
         if model_version == "E3SM-2-0":
             parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
+            cwl_workflow = "lnd-elm/lnd.cwl"
         else:
             parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
+            cwl_workflow = "lnd-n2n/lnd.cwl"
 
+        cwl_workflow_path = os.path.join(self.config['cwl_workflows_path'], cwl_workflow)
 
         # force dataset output version here
         ds_version = "v" + get_UTC_YMD()
@@ -115,6 +117,6 @@ class GenerateLndMonCMIP(WorkflowJob):
         # OVERRIDE : needed to be "pub_dir" to find the data, but back to "warehouse" to write results to the warehouse
         outpath = '/p/user_pub/e3sm/warehouse'  # was "self.dataset.warehouse_base", but -w <pub_root> for input selection interferes.
 
-        log_message("info", f"DEBUG-001: render out the CWL run command: cwltool --outdir {outpath} --tmpdir-prefix={self.tmpdir} --preserve-environment UDUNITS2_XML_PATH {os.path.join(self.config['cwl_workflows_path'], cwl_workflow)} {parameter_path}")
-        self._cmd = f"cwltool --outdir {outpath} --tmpdir-prefix={self.tmpdir} --preserve-environment UDUNITS2_XML_PATH {os.path.join(self.config['cwl_workflows_path'], cwl_workflow)} {parameter_path}"
+        log_message("info", f"DEBUG-001: render out the CWL run command: cwltool --outdir {outpath} --tmpdir-prefix={self.tmpdir} --preserve-environment UDUNITS2_XML_PATH {cwl_workflow_path} {parameter_path}")
+        self._cmd = f"cwltool --outdir {outpath} --tmpdir-prefix={self.tmpdir} --preserve-environment UDUNITS2_XML_PATH {cwl_workflow_path} {parameter_path}"
 

--- a/datasm/workflows/jobs/GenerateLndTimeseries.py
+++ b/datasm/workflows/jobs/GenerateLndTimeseries.py
@@ -20,10 +20,14 @@ class GenerateLndTimeseries(WorkflowJob):
         dsid = f"{self.dataset.dataset_id}"
         native_resolution = dsid.split(".")[3]
         # NOTE: available grids are defined in resources/datasm_config.yaml
-        mapkey = "ne30_to_180x360"
-        if native_resolution == "0_25deg_atm_18-6km_ocean":
-            mapkey = "ne120np4_to_cmip6_720x1440"
-            # or else maybe "ne120np4_to_cmip6_180x360"
+
+        mod_ver = self.dataset.model_version
+        if mod_ver == "2_0":
+            mapkey = "v2_ne30_to_180x360"
+        else:
+            mapkey = "v1_ne30_to_180x360"
+            if native_resolution == "0_25deg_atm_18-6km_ocean":
+                mapkey = "ne120pg2_to_cmip6_720x1440"
 
         map_path = self.config['grids'][mapkey]
 
@@ -37,7 +41,7 @@ class GenerateLndTimeseries(WorkflowJob):
         # see: /p/user_pub/e3sm/bartoletti1/Projects/Dynamic_YPF_Calculation
         ypf=50
 
-        flags = "-7 --dfl_lvl=1 --no_cell_measures "
+        flags = "-7 -P elm --dfl_lvl=1 --no_cell_measures "
         self._cmd = f"""
             ncclimo {flags} -v {','.join(variables)} -s {start} -e {end} -o {native_out} --map={map_path}  -O {self.dataset.latest_warehouse_dir} --ypf={ypf} -i {raw_dataset.latest_warehouse_dir} --sgs_frc={Path(raw_dataset.latest_warehouse_dir).glob('*.nc').__next__()}/landfrac
         """

--- a/datasm/workflows/jobs/GenerateOceanCMIP.py
+++ b/datasm/workflows/jobs/GenerateOceanCMIP.py
@@ -1,12 +1,11 @@
 import os
+import yaml
+import shutil
 from pathlib import Path
 from subprocess import PIPE, Popen
 from tempfile import NamedTemporaryFile
-
-import yaml
-
-from datasm.util import log_message, get_UTC_YMD, set_version_in_user_metadata
 from datasm.workflows.jobs import WorkflowJob
+from datasm.util import log_message, get_UTC_YMD, set_version_in_user_metadata, latest_aux_data
 
 NAME = 'GenerateOceanCMIP'
 
@@ -37,19 +36,30 @@ class GenerateOceanCMIP(WorkflowJob):
         if cmip_var in oa_vars:
             is_oa_var = True
 
-        # Begin parameters collection:  use 'mpas_data_path' and 'atm_data_path' for mpaso-atm.
+        # Begin parameters collection
+
+        parameters = dict()
+
+        # start with universal constants
+
+        parameters['tables_path'] = self.config['cmip_tables_path']
+
+        # Obtain latest data path 
+
+        # use 'mpas_data_path' and 'atm_data_path' for mpaso-atm.
         # including atmos-native_mon as (pbo requires PSL, etc)
         if is_oa_var:
             raw_ocean_dataset = self.requires['ocean-native-mon']
             raw_atmos_dataset = self.requires['atmos-native-mon']
-            parameters = { 'mpas_data_path': raw_ocean_dataset.latest_warehouse_dir, 'atm_data_path': raw_atmos_dataset.latest_warehouse_dir }
+            parameters['mpas_data_path'] = raw_ocean_dataset.latest_warehouse_dir
+            parameters['atm_data_path'] = raw_atmos_dataset.latest_warehouse_dir
         else:
             raw_ocean_dataset = self.requires['ocean-native-mon']
-            parameters = { 'data_path': raw_ocean_dataset.latest_warehouse_dir, }
+            parameters['data_path'] = raw_ocean_dataset.latest_warehouse_dir
 
         parameters.update(cwl_config)   # obtain frequency, num_workers, account, partition, timeout, slurm_timeout, mpas_region_path
 
-        # log_message("info", f"resolve_cmd: Obtained model_version {model_version}, experiment {experiment}, variant {variant}, table {table}, cmip_var {cmip_var}")
+        log_message("info", f"DBG: parameters['data_path'] = {parameters['data_path']}")
 
         # if we want to run all the variables
         # we can pull them from the dataset spec
@@ -114,41 +124,43 @@ class GenerateOceanCMIP(WorkflowJob):
             parameters['cmor_var_list'] = cmip_var
             cwl_workflow_main = "mpaso/mpaso.cwl"
 
-        parameters['tables_path'] = self.config['cmip_tables_path']
         cwl_workflow = os.path.join(self.config['cwl_workflows_path'], cwl_workflow_main)
-        metadata_path = os.path.join(self.config['cmip_metadata_path'],model_version,f"{experiment}_{variant}.json")
 
+        # Obtain metadata file, move to self._slurm_out for current-date-based version edit
+
+        metadata_name = f"{experiment}_{variant}.json"
+        metadata_path_src = os.path.join(self.config['cmip_metadata_path'],model_version,f"{metadata_name}")
+        shutil.copy(metadata_path_src,self._slurm_out)
+        metadata_path =  os.path.realpath(os.path.join(self._slurm_out,metadata_name))
         # force dataset output version here
         ds_version = "v" + get_UTC_YMD()
         set_version_in_user_metadata(metadata_path, ds_version)
         log_message("info", f"Set dataset version in {metadata_path} to {ds_version}")
-        
-        parameters['metadata'] = {
-            'class': 'File',
-            'path': metadata_path
-            }
+        parameters['metadata'] = { 'class': 'File', 'path': f"{metadata_path}" }
 
         if is_oa_var:
             parameters['metadata_path'] = parameters['metadata']
 
+        # Obtain mapfile and region_path by model_version
+
         if model_version == "E3SM-2-0":
-            parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
             parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v2_oEC60to30_to_180x360'] }
             parameters['region_path'] = parameters['v2_mpas_region_path']
         else:
-            parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
             parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v1_oEC60to30_to_180x360'] }
-            parameters['region_path'] = parameters['v1_mpas_region_path']
-
+            parameters['region_path'] = parameters['v2_mpas_region_path']
 
         if is_oa_var:
             parameters['mpas_map_path'] = self.config['grids']['oEC60to30_to_180x360']
 
-        raw_model_version = raw_ocean_dataset.model_version
-        raw_experiment = raw_ocean_dataset.experiment
+        namefile = latest_aux_data(self.dataset.dataset_id, "namefile", False)
+        restfile = latest_aux_data(self.dataset.dataset_id, "restart", True)
+        if namefile == "NONE" or restfile == "NONE":
+            log_message("error","Could not obtain namefile or restart file for job params")
+             
+        parameters['namelist_path'] = namefile
+        parameters['restart_path'] = restfile
 
-        parameters['namelist_path'] = os.path.join(self.config['e3sm_namefile_path'],raw_model_version,raw_experiment,'mpaso_in')
-        parameters['restart_path'] = os.path.join(self.config['e3sm_restarts_path'],raw_model_version,raw_experiment,'mpaso.rst.1851-01-01_00000.nc')
         parameters['workflow_output'] = '/p/user_pub/e3sm/warehouse'
 
         # step two, write out the parameter file and setup the temp directory

--- a/datasm/workflows/jobs/GenerateOceanCMIP.py
+++ b/datasm/workflows/jobs/GenerateOceanCMIP.py
@@ -131,12 +131,14 @@ class GenerateOceanCMIP(WorkflowJob):
         if is_oa_var:
             parameters['metadata_path'] = parameters['metadata']
 
-        parameters['region_path'] = parameters['mpas_region_path']
-        parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['oEC60to30_to_180x360'] }
         if model_version == "E3SM-2-0":
             parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
+            parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v2_oEC60to30_to_180x360'] }
+            parameters['region_path'] = parameters['v2_mpas_region_path']
         else:
             parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
+            parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v1_oEC60to30_to_180x360'] }
+            parameters['region_path'] = parameters['v1_mpas_region_path']
 
 
         if is_oa_var:

--- a/datasm/workflows/jobs/GenerateSeaIceCMIP.py
+++ b/datasm/workflows/jobs/GenerateSeaIceCMIP.py
@@ -99,9 +99,16 @@ class GenerateSeaIceCMIP(WorkflowJob):
             'class': 'File',
             'path': metadata_path
             }
-        parameters['region_path'] = parameters['mpas_region_path']
-        mapfile="/p/user_pub/e3sm/staging/resource/map_oEC60to30v3_to_cmip6_180x360_aave.20181001.nc"   # WARNING HARDCODED
-        parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['oEC60to30_to_180x360'] }
+
+        if model_version == "E3SM-2-0":
+            parameters['hrz_atm_map_path'] = self.config['grids']['v2_ne30_to_180x360']
+            parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v2_oEC60to30_to_180x360'] }
+            parameters['region_path'] = parameters['v2_mpas_region_path']
+        else:
+            parameters['hrz_atm_map_path'] = self.config['grids']['v1_ne30_to_180x360']
+            parameters['mapfile'] = { 'class': 'File', 'path': self.config['grids']['v1_oEC60to30_to_180x360'] }
+            parameters['region_path'] = parameters['v1_mpas_region_path']
+
         log_message("info", f"Applying to parameters[mapfile]: type = {type(parameters['mapfile'])}")
 
         raw_model_version = raw_seaice_dataset.model_version


### PR DESCRIPTION
This should close out the land, ocean and sea-ice job-setup changes for v2.  Future testing for GenerateAtm*CMIP.py (4 separate modules) will occur on a new branch.

Review is a hassle - sorry - as much of the changes are to restructure the ordering of actions to bring different modules in line as much as possible.