### PR TITLE
rationalized import statements, added v2_LE hacks

### DIFF
--- a/conda-env/proc.yml
+++ b/conda-env/proc.yml
@@ -15,7 +15,7 @@ dependencies:
   - netcdf4>=1.6.1
   - numpy>=1.22.1
   - pip>=21.2.4
-  - python>=3.9.13
+  - python=3.9.13
   - pyyaml>=6.0
   - termcolor>=1.1.0
   - tqdm>=4.64.1

--- a/datasm/dataset.py
+++ b/datasm/dataset.py
@@ -9,14 +9,11 @@ from pytz import UTC
 
 import ipdb
 
-from datasm.util import (
-    load_file_lines,
-    search_esgf,
-    get_last_status_line,
-    is_vdir_pattern,
-    log_message,
-)
-
+from datasm.util import get_last_status_line
+from datasm.util import is_vdir_pattern
+from datasm.util import load_file_lines
+from datasm.util import log_message
+from datasm.util import search_esgf
 
 class DatasetStatus(Enum):
     UNITITIALIZED = "DATASM:UNINITIALIZED:"

--- a/datasm/datasm.py
+++ b/datasm/datasm.py
@@ -28,6 +28,7 @@ resource_path, _ = os.path.split(resources.__file__)
 # Horrible
 DEFAULT_SPEC_PATH = os.path.join("/p/user_pub/e3sm/staging/resource", "dataset_spec.yaml")
 # DEFAULT_SPEC_PATH = os.path.join("/p/user_pub/e3sm/archive/External/E3SMv1_LE/resource", "v1_LE_dataset_spec.yaml")
+# DEFAULT_SPEC_PATH = os.path.join("/p/user_pub/e3sm/archive/External/E3SMv2_LE/resource", "v2_LE_dataset_spec.yaml")
 
 
 DEFAULT_CONF_PATH = os.path.join(resource_path, "datasm_config.yaml")
@@ -223,7 +224,7 @@ class AutoDataSM:
             warehouse_base=self.warehouse_path,
             archive_base=self.archive_path,
             no_status_file=True)
-        log_message("debug", f"find_e3sm_source_dataset: tries dsid {dataset.dataset_id}, calls 'requires_dataset()'")
+        log_message("info", f"find_e3sm_source_dataset: tries dsid {dataset.dataset_id}, calls 'requires_dataset()'")
         if job.requires_dataset(dataset):
             log_message("info", f"find_e3sm_source_dataset: dataset {dataset.dataset_id} matched job requirement")
             dataset.initialize_status_file()

--- a/datasm/scripts/unify_filenames_post_validation.py
+++ b/datasm/scripts/unify_filenames_post_validation.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 import glob

--- a/datasm/tools/archive_dataset_extractor.py
+++ b/datasm/tools/archive_dataset_extractor.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 import glob

--- a/datasm/tools/archive_extraction_service.py
+++ b/datasm/tools/archive_extraction_service.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 import glob
@@ -404,7 +405,7 @@ def main():
             
             tm_final = time.time()
             ET = tm_final - tm_start
-            logMessage('INFO',f'ARCHIVE_EXTRACTION_SERVICE:Completed file transfer to warehouse: filecount = {fcount}, ET = {ET}')
+            logMessage('INFO',f'ARCHIVE_EXTRACTION_SERVICE:Completed file transfer to warehouse: dsid={dsid}: filecount = {fcount}, ET = {ET}')
             logMessage('INFO', ' ');
             setStatus(statfile,'EXTRACTION',f'TRANSFER:Pass:dstdir=v0,filecount={fcount}')
             os.chdir(parentdir)

--- a/datasm/tools/archive_path_mapper.py
+++ b/datasm/tools/archive_path_mapper.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 import glob

--- a/datasm/tools/consolidated_cmip_dataset_report.py
+++ b/datasm/tools/consolidated_cmip_dataset_report.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 import argparse
 import re
 from argparse import RawTextHelpFormatter

--- a/datasm/tools/consolidated_e3sm_dataset_report.py
+++ b/datasm/tools/consolidated_e3sm_dataset_report.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 import argparse
 import re
 from argparse import RawTextHelpFormatter

--- a/datasm/tools/contract_dataset_spec.py
+++ b/datasm/tools/contract_dataset_spec.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 import yaml
 from argparse import RawTextHelpFormatter
 

--- a/datasm/tools/datasm_verify_publication.py
+++ b/datasm/tools/datasm_verify_publication.py
@@ -1,6 +1,7 @@
-import sys, os
-import json
+import os
+import sys
 import argparse
+import json
 from argparse import RawTextHelpFormatter
 
 import traceback

--- a/datasm/tools/expand_dataset_spec.py
+++ b/datasm/tools/expand_dataset_spec.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 import yaml
 from argparse import RawTextHelpFormatter
 

--- a/datasm/tools/list_cmip6_dsids.py
+++ b/datasm/tools/list_cmip6_dsids.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 import yaml
 from argparse import RawTextHelpFormatter
 

--- a/datasm/tools/list_e3sm_dsids.py
+++ b/datasm/tools/list_e3sm_dsids.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 import yaml
 from argparse import RawTextHelpFormatter
 

--- a/datasm/tools/metadata_version.py
+++ b/datasm/tools/metadata_version.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 from pathlib import Path

--- a/datasm/tools/parent_native_dsid.sh
+++ b/datasm/tools/parent_native_dsid.sh
@@ -6,6 +6,11 @@
 # CMIP6 Example:        CMIP6.C4MIP.E3SM-Project.E3SM-1-1-ECA.hist-bgc.r1i1p1f1.3hr.pr.gr
 #       project.activity.institution.sourceid.experiment.variant.freq.var.grid
 
+if [ $# -eq 0 ]; then
+    echo "NONE: No dataset_id supplied"
+    exit 1
+fi
+
 dsid=$1
 
 
@@ -59,8 +64,10 @@ if [[ $institute != "E3SM-Project" && $institute != "UCSB" ]]; then
     exit 0
 fi
 
-modelversion=`echo $source_id | cut -f2- -d- | tr - _`
+modelversion=`echo $source_id | cut -f2- -d- | tr - _`  # CMIP6 dsids will NOT have "-LE" in the Source_ID
 # what about HR campaign?
+
+# HACK for NARRM
 if [ $modelversion == "2_0" ]; then
     resolution="LR"
 elif [ $modelversion == "2_0_NARRM" ]; then
@@ -72,6 +79,14 @@ fi
 # HACK for v1_Large_Ensemble (External)
 if [[ $modelversion == "1_0" && $institute == "UCSB" ]]; then
     modelversion="1_0_LE"
+fi
+
+# HACK for v2_Large_Ensemble (External)
+if [[ $modelversion == "2_0" ]]; then
+    rdex=`echo $variant | cut -f1 -di | cut -c2-`
+    if [[ $rdex -ge 6 ]]; then
+        modelversion="2_0_LE"
+    fi
 fi
 
 grid="native"

--- a/datasm/tools/rw_yaml.py
+++ b/datasm/tools/rw_yaml.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 import yaml
 from argparse import RawTextHelpFormatter
 

--- a/datasm/tools/tell_years_dsid.py
+++ b/datasm/tools/tell_years_dsid.py
@@ -1,6 +1,7 @@
-import os, sys
-import yaml
+import os
+import sys
 import argparse
+import yaml
 from argparse import RawTextHelpFormatter
 
 

--- a/datasm/tools/trisect.py
+++ b/datasm/tools/trisect.py
@@ -1,4 +1,6 @@
-import os, sys, argparse
+import os
+import sys
+import argparse
 
 # Given two files of lines, convert each to sets of lines A and B.
 # Output the set differences A-B and B-A, and intersection A&B.

--- a/datasm/tools/update_json_value.py
+++ b/datasm/tools/update_json_value.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import argparse
 from argparse import RawTextHelpFormatter
 from pathlib import Path

--- a/datasm/workflows/jobs/GenerateAtmDayCMIP.py
+++ b/datasm/workflows/jobs/GenerateAtmDayCMIP.py
@@ -24,11 +24,13 @@ class GenerateAtmDayCMIP(WorkflowJob):
         raw_dataset = self.requires['atmos-native-day']
         cwl_config = self.config['cmip_atm_day']
 
-        # log_message("debug", f"Using raw input from {raw_dataset.latest_warehouse_dir}")
-        parameters = {'data_path': raw_dataset.latest_warehouse_dir}
+        _, _, institution, model_version, experiment, variant, table, cmip_var, _ = self.dataset.dataset_id.split('.')
+
+        parameters = dict()
         parameters.update(cwl_config)   # obtain frequency, num_workers, account, partition, e2c_timeout, slurm_timeout
 
-        _, _, institution, model_version, experiment, variant, table, cmip_var, _ = self.dataset.dataset_id.split('.')
+        data_path = raw_dataset.latest_warehouse_dir
+        parameters['data_path'] = data_path
 
         # if we want to run all the variables
         # we can pull them from the dataset spec
@@ -47,7 +49,8 @@ class GenerateAtmDayCMIP(WorkflowJob):
         info_file = NamedTemporaryFile(delete=False)
         log_message("info", f"Obtained temp info file name: {info_file.name}")
         cmip_out = os.path.join(self._slurm_out, "CMIP6")
-        cmd = f"e3sm_to_cmip --info -i {parameters['data_path']} -o {cmip_out} -u {metadata_path} --freq day -v {', '.join(in_cmip_vars)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
+        var_str = ', '.join(in_cmip_vars)
+        cmd = f"e3sm_to_cmip --info --map none -i {data_path} -o {cmip_out} -u {metadata_path} --freq day -v {var_str} -t {self.config['cmip_tables_path']} --info-out {info_file.name} --realm atm"
         log_message("info", f"resolve_cmd: issuing variable info cmd: {cmd}")
 
         proc = Popen(cmd.split(), stdout=PIPE, stderr=PIPE)

--- a/datasm/workflows/jobs/GenerateAtmFixedCMIP.py
+++ b/datasm/workflows/jobs/GenerateAtmFixedCMIP.py
@@ -49,7 +49,8 @@ class GenerateAtmFixedCMIP(WorkflowJob):
         info_file = NamedTemporaryFile(delete=False)
         log_message("info", f"Obtained temp info file name: {info_file.name}")
         cmip_out = os.path.join(self._slurm_out, "CMIP6")
-        cmd = f"e3sm_to_cmip --info -i {data_path} -o {cmip_out} -u {metadata_path} --freq mon -v {', '.join(in_cmip_vars)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
+        var_str = ', '.join(in_cmip_vars)
+        cmd = f"e3sm_to_cmip --info --map none -i {data_path} -o {cmip_out} -u {metadata_path} --freq mon -v {var_str} -t {self.config['cmip_tables_path']} --info-out {info_file.name} --realm atm"
         log_message("info", f"resolve_cmd: issuing variable info cmd: {cmd}")
 
         proc = Popen(cmd.split(), stdout=PIPE, stderr=PIPE)

--- a/datasm/workflows/jobs/GenerateAtmMonCMIP.py
+++ b/datasm/workflows/jobs/GenerateAtmMonCMIP.py
@@ -1,5 +1,6 @@
+import os
+import sys
 import yaml
-import os, sys
 
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
@@ -23,10 +24,13 @@ class GenerateAtmMonCMIP(WorkflowJob):
         raw_dataset = self.requires['atmos-native-mon']
         cwl_config = self.config['cmip_atm_mon']
 
-        parameters = {'data_path': raw_dataset.latest_warehouse_dir}
+        _, _, institution, cmip_model_version, experiment, variant, table, cmip_var, _ = self.dataset.dataset_id.split('.')
+
+        parameters = dict()
         parameters.update(cwl_config)   # obtain frequency, num_workers, account, partition, e2c_timeout, slurm_timeout
 
-        _, _, institution, cmip_model_version, experiment, variant, table, cmip_var, _ = self.dataset.dataset_id.split('.')
+        data_path = raw_dataset.latest_warehouse_dir
+        parameters['data_path'] = data_path
 
         # seek "cmip_model_version" for v2 accommodations
 
@@ -51,7 +55,8 @@ class GenerateAtmMonCMIP(WorkflowJob):
 
         info_file = NamedTemporaryFile(delete=False)
         cmip_out = os.path.join(self._slurm_out, "CMIP6")
-        cmd = f"e3sm_to_cmip --info -i {parameters['data_path']} -o {cmip_out} -u {metadata_path} --freq mon -v {', '.join(cmip_var)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
+        var_str = ', '.join(cmip_var)
+        cmd = f"e3sm_to_cmip --info --map none -i {data_path} -o {cmip_out} -u {metadata_path} --freq mon -v {var_str} -t {self.config['cmip_tables_path']} --info-out {info_file.name} --realm atm"
         log_message("info", f"resolve_cmd: calling e2c: CMD = {cmd}")
 
         print(f"DEBUG: calling e2c: CMD = {cmd}", flush=True)

--- a/datasm/workflows/jobs/GenerateLndMonCMIP.py
+++ b/datasm/workflows/jobs/GenerateLndMonCMIP.py
@@ -49,7 +49,8 @@ class GenerateLndMonCMIP(WorkflowJob):
 
         # Obtain latest data path
 
-        parameters['data_path'] = raw_dataset.latest_warehouse_dir
+        data_path = raw_dataset.latest_warehouse_dir
+        parameters['data_path'] = data_path
 
         parameters.update(cwl_config)   # obtain frequency, num_workers, account, partition, e2c_timeout, slurm_timeout
 
@@ -73,7 +74,8 @@ class GenerateLndMonCMIP(WorkflowJob):
 
         info_file = NamedTemporaryFile(delete=False)
         cmip_out = os.path.join(self._slurm_out, "CMIP6")
-        cmd = f"e3sm_to_cmip -i {parameters['data_path']} -o {cmip_out} -u {metadata_path} --info --map none --realm lnd -v {', '.join(cmip_var)} -t {self.config['cmip_tables_path']} --info-out {info_file.name}"
+        var_str = ', '.join(cmip_var)
+        cmd = f"e3sm_to_cmip --info --map none -i {data_path} -o {cmip_out} -u {metadata_path} --freq mon -v {var_str} -t {self.config['cmip_tables_path']} --info-out {info_file.name} --realm lnd"
         log_message("info", f"resolve_cmd: E2C --info call cmd = {cmd}")
         proc = Popen(cmd.split(), stdout=PIPE, stderr=PIPE)
         _, err = proc.communicate()

--- a/datasm/workflows/jobs/__init__.py
+++ b/datasm/workflows/jobs/__init__.py
@@ -1,4 +1,5 @@
-import sys, os
+import os
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -170,6 +171,7 @@ fi
                 return None
         else:
             dataset_facets = dataset.dataset_id.split('.')
+            log_message("info", f"init: requires_dataset(): dataset.dataset_id = {dataset.dataset_id}")
             if self.dataset.project == 'CMIP6' and dataset.project == 'E3SM':
                 e3sm_cmip_case = self._spec['project']['E3SM'][dataset_facets[1]][dataset_facets[2]].get('cmip_case')
                 # reject if this E3SM dataset does not have a "cmip_case" in the dataset_spec.
@@ -193,7 +195,7 @@ fi
         if '_' in dst_dataset_model:
             dst_dataset_model = 'E3SM-' + '-'.join(self.dataset.model_version.split('_'))
         if src_dataset_model != dst_dataset_model:
-            if src_dataset_model != "E3SM-1-0-LE": # HACK to accommodate v1_Large_Ensemble
+            if src_dataset_model not in [ "E3SM-1-0-LE", "E3SM-2-0-LE" ] : # HACK to accommodate v1_Large_Ensemble and v2_Large_Ensemble
                 log_message("info", f"init: requires_dataset: ERR: src_dataset_model = {src_dataset_model} but dst_dataset_model = {dst_dataset_model}")
                 # reject if (translated) model does not match
                 return None


### PR DESCRIPTION
Expanded import statements to singletons for easier assessments.  Expanded and cleaned up HACKS for v1_LE, v2_LE and NARRM modelVersion and resolution translations (should be captured and processed by an external translation table, not sprinkled in the codes), and standardized the Generate___CMIP e2c --info calls.