### PR TITLE
fixed typo, logic failure, and added try code to popen

### DIFF
--- a/datasm/tools/archive_extraction_service.py
+++ b/datasm/tools/archive_extraction_service.py
@@ -21,7 +21,7 @@ gv_stat_root = dsm_paths["STAGING_STATUS"]
 
 gv_holospace = f"{staging}/holospace"
 gv_input_dir = f"{archman}/extraction_requests_pending"
-gv_output_dir = f"{archman}/extraction_requests_processsed"
+gv_output_dir = f"{archman}/extraction_requests_processed"
 
 helptext = '''
 

--- a/datasm/tools/datasm_verify_publication.py
+++ b/datasm/tools/datasm_verify_publication.py
@@ -314,10 +314,11 @@ def main():
         # establish project
         project = dsid.split(".")[0]
         if project == "E3SM":
-            project = project.lower()
+            project = project.lower()       # required to satisfy esgf tables ...
         add_facet = dict()
         if project == "CMIP6" and not pargs.unrestricted:
-            add_facet = { "institution_id": "E3SM-Project" }
+            institution = dsid.split(".")[2]
+            add_facet = { "institution_id": institution }
 
         got_sfile = False
         got_stats = False

--- a/datasm/tools/parent_native_dsid.sh
+++ b/datasm/tools/parent_native_dsid.sh
@@ -139,6 +139,8 @@ if [ ${modelversion:0:3} == "1_1" ]; then
         experiment="ssp585-BDRC"
     elif [ $cmip_exp == "ssp585" ]; then
         experiment="ssp585-BDRD"
+    else
+        experiment=$cmip_exp
     fi
 else
     experiment=$cmip_exp

--- a/datasm/workflows/jobs/__init__.py
+++ b/datasm/workflows/jobs/__init__.py
@@ -286,6 +286,7 @@ fi
     def find_outpath(self):
         latest_path = self._dataset.latest_warehouse_dir
         # assuming the path ends in something like "v0" or "v0.1"
+        log_message("info", f"init: self.find_outpath says self._dataset.latest_warehouse_dir = {latest_path}")
         version = latest_path.split('v')[-1]
         if '.' in version:
             version_number = int(version.split('.')[-1])


### PR DESCRIPTION
archive_extraction_service.py had a typo in a directory name ("processsed...").
archive_path_mapper.py had a typo in a variable name ("userroot" vs "user_root"), and added "try" to popen() for proper exit handling.
parent_native_dsid.sh was missing a default experiment value.