### PR TITLE
various config updates to handle v2_1 datasets

### DIFF
--- a/datasm/resources/dataset_spec.yaml
+++ b/datasm/resources/dataset_spec.yaml
@@ -912,8 +912,6 @@ project:
                         end: 2014
                         ens:
                             - r1i1p1f1
-                            - r2i1p1f1
-                            - r3i1p1f1
                         except:
                             - Omon
                             - Ofx
@@ -4897,8 +4895,6 @@ project:
                 end: 2014
                 ens:
                     - ens1
-                    - ens2
-                    - ens3
                 campaign: DECK-v2
                 science_driver: Water Cycle
                 cmip_case: CMIP6.CMIP.E3SM-Project.E3SM-2-1.amip

--- a/datasm/resources/derivatives.conf
+++ b/datasm/resources/derivatives.conf
@@ -19,6 +19,9 @@ atmos,LR-NARRM,2_0_NARRM,CASE_FINDER,\.eam\.h\d\.
 atmos,HR,2_0,REGRID,map_ne120pg2_to_cmip6_720x1440_aave.20200201.nc
 atmos,HR,2_0,FILE_SELECTOR,.eam.h
 atmos,HR,2_0,CASE_FINDER,\.eam\.h\d\.
+atmos,LR,2_1,REGRID,map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
+atmos,LR,2_1,FILE_SELECTOR,.eam.h
+atmos,LR,2_1,CASE_FINDER,\.eam\.h\d\.
 land,1deg_atm_60-30km_ocean,1_0,REGRID,map_ne30np4_to_cmip6_180x360_aave.20181001.nc
 land,1deg_atm_60-30km_ocean,1_0,FILE_SELECTOR,.clm2.h
 land,1deg_atm_60-30km_ocean,1_0,CASE_FINDER,\.clm2\.h\d\.
@@ -40,6 +43,9 @@ land,LR-NARRM,2_0_NARRM,CASE_FINDER,\.elm\.h\d\.
 land,HR,2_0,REGRID,map_ne120pg2_to_cmip6_720x1440_aave.20200201.nc
 land,HR,2_0,FILE_SELECTOR,.elm.h
 land,HR,2_0,CASE_FINDER,\.elm\.h\d\.
+land,LR,2_1,REGRID,map_ne30pg2_to_cmip6_180x360_aave.20200201.nc
+land,LR,2_1,FILE_SELECTOR,.elm.h
+land,LR,2_1,CASE_FINDER,\.elm\.h\d\.
 ocean,1deg_atm_60-30km_ocean,1_0,REGRID,map_oEC60to30v3_to_cmip6_180x360_aave.20181001.nc
 ocean,1deg_atm_60-30km_ocean,1_0,MASK,oEC60to30v3_Atlantic_region_and_southern_transect.nc
 ocean,1deg_atm_60-30km_ocean,1_0_LE,REGRID,map_oEC60to30v3_to_cmip6_180x360_aave.20181001.nc
@@ -50,6 +56,8 @@ ocean,LR,2_0_LE,REGRID,map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
 ocean,LR,2_0_LE,MASK,EC30to60E2r2_mocBasinsAndTransects20210623.nc
 ocean,LR-NARRM,2_0_NARRM,REGRID,map_WC14to60E2r5_to_cmip6_180x360_aave.20230313.nc
 ocean,LR-NARRM,2_0_NARRM,MASK,WC14to60E2r5_mocBasinsAndTransects20210623.nc
+ocean,LR,2_1,REGRID,map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
+ocean,LR,2_1,MASK,EC30to60E2r2_mocBasinsAndTransects20210623.nc
 sea-ice,1deg_atm_60-30km_ocean,1_0,REGRID,map_oEC60to30v3_to_cmip6_180x360_aave.20181001.nc
 sea-ice,1deg_atm_60-30km_ocean,1_0,MASK,oEC60to30v3_Atlantic_region_and_southern_transect.nc
 sea-ice,1deg_atm_60-30km_ocean,1_0_LE,REGRID,map_oEC60to30v3_to_cmip6_180x360_aave.20181001.nc
@@ -60,4 +68,6 @@ sea-ice,LR,2_0_LE,REGRID,map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
 sea-ice,LR,2_0_LE,MASK,EC30to60E2r2_mocBasinsAndTransects20210623.nc
 sea-ice,LR-NARRM,2_0_NARRM,REGRID,map_WC14to60E2r5_to_cmip6_180x360_aave.20230313.nc
 sea-ice,LR-NARRM,2_0_NARRM,MASK,WC14to60E2r5_mocBasinsAndTransects20210623.nc
+sea-ice,LR,2_1,REGRID,map_EC30to60E2r2_to_cmip6_180x360_aave.20220301.nc
+sea-ice,LR,2_1,MASK,EC30to60E2r2_mocBasinsAndTransects20210623.nc
 

--- a/datasm/tools/ensure_status_file_for_dsid.sh
+++ b/datasm/tools/ensure_status_file_for_dsid.sh
@@ -6,6 +6,8 @@ sf_root1=`$DSM_GETPATH STAGING_STATUS`
 staging=`$DSM_GETPATH DSM_STAGING`
 sf_root2=$staging/status_ext
 
+project=`echo $dsid | cut -f1 -d.`
+
 if [ $project == "CMIP6" ]; then
     instid=`echo $dsid | cut -f3 -d.`
     if [[ $instid == "E3SM-Project" || $instid == "UCSB" ]]; then

--- a/datasm/tools/parent_native_dsid.sh
+++ b/datasm/tools/parent_native_dsid.sh
@@ -68,10 +68,12 @@ modelversion=`echo $source_id | cut -f2- -d- | tr - _`  # CMIP6 dsids will NOT h
 # what about HR campaign?
 
 # HACK for NARRM
-if [ $modelversion == "2_0" ]; then
+if [ $modelversion == "2_1" ]; then
     resolution="LR"
 elif [ $modelversion == "2_0_NARRM" ]; then
     resolution="LR-NARRM"
+elif [ $modelversion == "2_0" ]; then
+    resolution="LR"
 else
     resolution="1deg_atm_60-30km_ocean"
 fi

--- a/datasm/util.py
+++ b/datasm/util.py
@@ -508,6 +508,8 @@ def set_e3sm_model_resolution_ensemble(sourceid,institution,experiment,variant):
         resol = "LR"
     elif src_model == "2_0_NARRM":
         resol = "LR-NARRM"
+    elif src_model == "2_1":
+        resol = "LR"
     else:
         resol = "1deg_atm_60-30km_ocean"
 


### PR DESCRIPTION
There are TOO MANY places where v2_1 versus other model-version material configs must be updated.  Convering CMIP6 dsids to native source dsids defaults to resolution "1deg_atm_60-30km_ocean", unless model-version is 2_0, 2_0_NARRM.  Needed to add case for 2_1, so that resolution "LR" would be applied.  Likewise, regrid maps for v1_* differ from v2_0, and v2_NARRM, but no entries for v2_1 had been provided.  We should find a way to make such config changes/additions centralized, and part of the "accepting new simulation output" procedures.