### PR TITLE
fixed var-name inconsistency in some cwl_workflows

### DIFF
--- a/datasm/cwl_workflows/fx/fx.cwl
+++ b/datasm/cwl_workflows/fx/fx.cwl
@@ -18,7 +18,7 @@ inputs:
 
   # cmor
   tables_path: string
-  metadata: string
+  metadata_file: string
 
 outputs:
   cmorized:
@@ -43,7 +43,7 @@ steps:
     run: cmor.cwl
     in:
       tables_path: tables_path
-      metadata: metadata
+      metadata: metadata_file
       var_list: cmor_var_list
       raw_file: step_hrzmap/remapped_fx
     out:

--- a/datasm/cwl_workflows/mpaso/mpaso.cwl
+++ b/datasm/cwl_workflows/mpaso/mpaso.cwl
@@ -7,7 +7,7 @@ requirements:
 
 inputs:
   data_path: string
-  metadata: string
+  metadata_file: string
   workflow_output: string
 
   mapfile: string
@@ -54,7 +54,7 @@ steps:
     in:
       input_path: step_segments/segments
       tables_path: tables_path
-      metadata: metadata
+      metadata: metadata_file
       var_list: cmor_var_list
       mapfile: mapfile
       slurm_timeout: slurm_timeout

--- a/datasm/workflows/jobs/GenerateAtmFixedCMIP.py
+++ b/datasm/workflows/jobs/GenerateAtmFixedCMIP.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 from datasm.workflows.jobs import WorkflowJob
-from datasm.util import log_message, get_e2c_info, parent_native_dsid, latest_data_vdir, prepare_cmip_job_metadata, derivative_conf
+from datasm.util import log_message, get_first_nc_file, get_e2c_info, parent_native_dsid, latest_data_vdir, prepare_cmip_job_metadata, derivative_conf
 
 NAME = 'GenerateAtmFixedCMIP'
 
@@ -53,7 +53,7 @@ class GenerateAtmFixedCMIP(WorkflowJob):
         parameters['tables_path'] = tables_path
         parameters['data_path'] = data_path
         parameters['atm_data_path'] = data_path_dict
-        parameters['metadata_path'] = metadata_file
+        parameters['metadata_file'] = metadata_file
 
         parameters['std_var_list']  = var_info['natv_vars']
         parameters['cmor_var_list'] = var_info['cmip_vars']

--- a/datasm/workflows/jobs/GenerateOcnFixedCMIP.py
+++ b/datasm/workflows/jobs/GenerateOcnFixedCMIP.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import yaml
 from datasm.workflows.jobs import WorkflowJob
-from datasm.util import log_message, get_e2c_info, parent_native_dsid, latest_data_vdir, prepare_cmip_job_metadata, derivative_conf
+from datasm.util import log_message, get_first_nc_file, get_e2c_info, parent_native_dsid, latest_data_vdir, prepare_cmip_job_metadata, derivative_conf
 
 NAME = 'GenerateOcnFixedCMIP'
 
@@ -56,7 +56,7 @@ class GenerateOcnFixedCMIP(WorkflowJob):
         parameters['tables_path'] = tables_path
         parameters['data_path'] = data_path
         parameters['ocn_data_path'] = data_path_dict
-        parameters['metadata_path'] = metadata_path
+        parameters['metadata_file'] = metadata_file
 
         parameters['std_var_list']  = var_info['natv_vars']
         parameters['cmor_var_list'] = var_info['cmip_vars']


### PR DESCRIPTION
Inconsistent var names ("metadata", "metadata_path", "metadata_file") caused failures in the "fx" and "Ofx" processing.