### PR TITLE
replaced pytz.utc with datetime.timezone over deprecation warning

### DIFF
--- a/datasm/dataset.py
+++ b/datasm/dataset.py
@@ -4,8 +4,7 @@ import sys
 from enum import Enum
 
 from pathlib import Path
-from datetime import datetime
-from pytz import UTC
+from datetime import datetime, timezone
 
 import ipdb
 
@@ -414,7 +413,7 @@ class Dataset(object):
         self._status = status
 
         with open(self.status_path, "a") as outstream:
-            tstamp =  UTC.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+            tstamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
             # msg = f'STAT:{tstamp}:DATASM:{status}'
             msg = f'STAT:{tstamp}:{status}'
             if params is not None:

--- a/datasm/tools/archive_dataset_extractor.py
+++ b/datasm/tools/archive_dataset_extractor.py
@@ -5,8 +5,7 @@ import glob
 import shutil
 from subprocess import Popen, PIPE, check_output
 import time
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 helptext = '''
     Usage:  archive_dataset_extractor -a am_specfile [-d dest_dir] [-O]
@@ -33,7 +32,7 @@ holodeck = ''
 holozst = ''
 
 def ts():
-    return 'TS_' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return 'TS_' + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 
 def assess_args():

--- a/datasm/tools/archive_extraction_service.py
+++ b/datasm/tools/archive_extraction_service.py
@@ -6,8 +6,7 @@ import shutil
 from datasm.util import get_dsm_paths
 from subprocess import Popen, PIPE, check_output
 import time
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 from pathlib import Path
 
 gv_logname = ''
@@ -44,7 +43,7 @@ helptext = '''
 # ======== convenience ========================
 
 def ts(prefix):
-    return prefix + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return prefix + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 def assess_args():
 

--- a/datasm/tools/archive_path_mapper.py
+++ b/datasm/tools/archive_path_mapper.py
@@ -6,8 +6,7 @@ import shutil
 from subprocess import Popen, PIPE, check_output
 from datasm.util import get_dsm_paths
 import time
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 helptext = '''
     Usage:  archive_path_mapper -a al_listfile [-s sdepfile]
@@ -47,12 +46,12 @@ x_pattern = ''
 
 
 def ts():
-    return 'TS_' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return 'TS_' + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 out_log = f"{thePWD}/runlog-{ts()}"
 
 def logmsg(msg):
-    ts = pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     with open(out_log, "a+") as outstream:
         outstream.write(f"{ts}: {msg}\n")
 

--- a/datasm/tools/consolidated_cmip_dataset_report.py
+++ b/datasm/tools/consolidated_cmip_dataset_report.py
@@ -4,8 +4,7 @@ import re
 from argparse import RawTextHelpFormatter
 import requests
 import time
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 import yaml
 from datasm.util import get_dsm_paths
 
@@ -55,7 +54,7 @@ ARCHMAP = f"{ARCHMAN}/Archive_Map"
 gv_csv = True
 
 def ts():
-    return pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 def assess_args():
 

--- a/datasm/tools/consolidated_e3sm_dataset_report.py
+++ b/datasm/tools/consolidated_e3sm_dataset_report.py
@@ -4,8 +4,7 @@ import re
 from argparse import RawTextHelpFormatter
 import requests
 import time
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 import yaml
 from datasm.util import get_dsm_paths
 
@@ -55,7 +54,7 @@ ARCHMAP = f"{ARCHMAN}/Archive_Map"
 gv_csv = True
 
 def ts():
-    return pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 def assess_args():
 

--- a/datasm/tools/datasm_verify_publication.py
+++ b/datasm/tools/datasm_verify_publication.py
@@ -12,8 +12,7 @@ import time
 from tempfile import NamedTemporaryFile
 from subprocess import Popen, PIPE
 from pathlib import Path
-from datetime import datetime
-from pytz import UTC
+from datetime import datetime, timezone
 from termcolor import colored, cprint
 from datasm.util import get_dsm_paths
 
@@ -21,7 +20,7 @@ from datasm.util import get_dsm_paths
 # -----------------------------------------------
 
 def ts():
-    return 'TS_' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return 'TS_' + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 
 helptext = '''
@@ -70,7 +69,7 @@ def assess_args():
 
 
 def setup_logging(loglevel, logpath):
-    logname = logpath + "-" + UTC.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    logname = logpath + "-" + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     if loglevel == "debug":
         level = logging.DEBUG
     elif loglevel == "error":
@@ -107,7 +106,7 @@ def log_message(level, message, user_level='INFO'):  # message BOTH to log file 
     level = level.upper()
     colors = {"INFO": "white", "WARNING": "yellow", "ERROR": "red", "DEBUG": "cyan"}
     color = colors.get(level, 'red')
-    tstamp = UTC.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")  # for console output
+    tstamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     # first, print to logfile
     if level == "DEBUG":
         logging.debug(message)
@@ -285,7 +284,7 @@ def get_last_status_value(statlist):
 def set_last_status_value(statfile,status_str):
     if os.access(statfile, os.W_OK):
         with open(statfile, "a") as outstream:
-            tstamp =  UTC.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+            tstamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
             msg = f'STAT:{tstamp}:{status_str}'
             outstream.write(msg + "\n")
     else:

--- a/datasm/tools/metadata_version.py
+++ b/datasm/tools/metadata_version.py
@@ -2,17 +2,14 @@ import sys, os
 import argparse
 from argparse import RawTextHelpFormatter
 from pathlib import Path
-import glob
 import json
 import shutil
-import subprocess
 import time
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 
 # 
 def ts():
-    return 'TS_' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return 'TS_' + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 
 helptext = '''
@@ -74,7 +71,7 @@ def main():
         print(f"{meta_version}")
 
     if mode == "set":
-        version = 'v' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d")
+        version = 'v' + datetime.now(timezone.utc).strftime("%Y%m%d")
         set_version_in_user_metadata(meta_file, version)
 
     sys.exit(0)

--- a/datasm/tools/rw_yaml.py
+++ b/datasm/tools/rw_yaml.py
@@ -103,6 +103,9 @@ def main():
     gv_dosort = pargs.sort
 
     in_dict = load_yaml(pargs.infile)
+
+    #print(f"DEBUG:rw_yaml: load_yaml returned type {type(in_dict)}")
+
     yaml_write(in_dict,pargs.tabsize)
 
     sys.exit(0)

--- a/datasm/tools/update_json_value.py
+++ b/datasm/tools/update_json_value.py
@@ -7,12 +7,11 @@ import json
 import shutil
 import subprocess
 import time
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 
 # 
 def ts():
-    return 'TS_' + pytz.utc.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return 'TS_' + datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 
 helptext = '''

--- a/datasm/util.py
+++ b/datasm/util.py
@@ -15,16 +15,15 @@ import xarray as xr
 from tempfile import NamedTemporaryFile
 from subprocess import Popen, PIPE
 from pathlib import Path
-from datetime import datetime
-from pytz import UTC
+from datetime import datetime, timezone
 from termcolor import colored, cprint
 
 
 def get_UTC_TS():
-    return UTC.localize(datetime.utcnow()).strftime("%Y%m%d_%H%M%S_%f")
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 def get_UTC_YMD():
-   return UTC.localize(datetime.utcnow()).strftime("%Y%m%d")
+   return datetime.now(timezone.utc).strftime("%Y%m%d")
 
 
 def load_file_lines(file_path):
@@ -308,6 +307,8 @@ def get_dataset_version_from_file_metadata(latest_dir):  # input latest_dir alre
     if first_file == None:
         log_message("info", f"No first_file")
         return 'NONE'
+
+    log_message("error", f"(Fake_Error) Testing for version in file {first_file}")
 
     ds = xr.open_dataset(first_file)
     if 'version' in ds.attrs.keys():


### PR DESCRIPTION
The former use of

> import pytz
> from datetime import datetime

to issue

> pytz.utc.localize(datetime.utcnow())

was producing the warning on EVERY invocation:

> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

The replacement is:

> from datetime import datetime, timezone

to issue

> datetime.now(timezone.utc)

